### PR TITLE
修改获取 keyWindow 方式，及相关调用。

### DIFF
--- a/FlexLib/Classes/FlexBaseVC.m
+++ b/FlexLib/Classes/FlexBaseVC.m
@@ -372,7 +372,7 @@ static void* gObserverFrame = &gObserverFrame;
 {
     CGRect keyboardFrame = [[[notification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     
-    UIWindow *window = [[[UIApplication sharedApplication] windows]objectAtIndex:0];
+    UIWindow *window = keyWindow();
     UIView *mainView = window.rootViewController.view;
     CGRect rcFrameConverted = [mainView convertRect:keyboardFrame fromView:window];
     

--- a/FlexLib/Classes/FlexUtils.h
+++ b/FlexLib/Classes/FlexUtils.h
@@ -124,6 +124,8 @@ BOOL IsIphoneX(void);
 
 BOOL IsPortrait(void);
 
+UIWindow* keyWindow(void);
+
 //获取自1970/1/1到现在的精确秒数，精确到微秒
 double GetAccurateSecondsSince1970(void);
 

--- a/FlexLib/Classes/FlexUtils.m
+++ b/FlexLib/Classes/FlexUtils.m
@@ -224,7 +224,7 @@ BOOL IsIphoneX(void)
             
             if(@available(iOS 11.0,*)){
                 
-                UIWindow* mainWindow = [[[UIApplication sharedApplication]delegate]window];
+                UIWindow *mainWindow = keyWindow();
                 
                 if(mainWindow.safeAreaInsets.bottom>0){
                     iphoneX = 1;
@@ -238,6 +238,18 @@ BOOL IsPortrait(void)
 {
     CGRect rcScreen = [[UIScreen mainScreen]bounds];
     return rcScreen.size.height > rcScreen.size.width ;
+}
+
+UIWindow* keyWindow(void)
+{
+    UIWindow *keyWindow = nil;
+    for (UIWindow *window in UIApplication.sharedApplication.windows) {
+        if (window.isKeyWindow) {
+            keyWindow = window;
+            break;
+        }
+    }
+    return keyWindow;
 }
 
 double GetAccurateSecondsSince1970()
@@ -306,7 +318,7 @@ FlexLanuage FlexGetLanguage(void)
 }
 -(void)show:(CGFloat)durationInSec
 {
-    UIWindow* window =  [UIApplication sharedApplication].keyWindow;
+    UIWindow* window = keyWindow();
 
     [window addSubview:self.label];
     [window bringSubviewToFront:self.label];


### PR DESCRIPTION
Xcode 11 建新工程默认会创建通过 UIScene 管理多个 UIWindow 的应用，AppDelegate.h 不再有 `window` 属性，需要通过新的方式获取，否则会出现崩溃：

> -[AppDelegate window]: unrecognized selector sent to instance 0x6000023cc030
